### PR TITLE
Bump Ruby 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Here is an example application with the following modern web technology stacks. With this boilerplate, you can easily start to build your own app.**
 
-- [Ruby](https://www.ruby-lang.org/en/) 2.5.1
+- [Ruby](https://www.ruby-lang.org/en/) 2.6.0
 - [Rails](https://rubyonrails.org/) 5.2.1
 - [React.js](https://reactjs.org/) 16.5.0
 - [TypeScript](https://www.typescriptlang.org/) 3.0.3

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.6
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 RUN mkdir -p /myapp/backend
 WORKDIR /myapp/backend

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
+ruby '2.6.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
-    rake (12.3.1)
+    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -216,7 +216,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.6.0p0
 
 BUNDLED WITH
-   1.16.2
+   1.17.3


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/