### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,2 @@
-bundle eol=lf
-rails eol=lf
-rake eol=lf
-setup eol=lf
-spring eol=lf
-update eol=lf
-yarn eol=lf
+backend/bin/* eol=lf
 prehook eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+bundle eol=lf
+rails eol=lf
+rake eol=lf
+setup eol=lf
+spring eol=lf
+update eol=lf
+yarn eol=lf
+prehook eol=lf


### PR DESCRIPTION
**Add .gitattributes for easy windows setup**
This will ensure that on checkout, all files with `#!/usr/bin/env bash` at the top keep the Unix (LF) file endings. Otherwise you may get a weird error on windows when running `docker-compose run backend bin/rails db:create db:migrate`

Also, if there's a better way to list out each of the bash files, please let me know.